### PR TITLE
[PSK-63] User & Image endpoint

### DIFF
--- a/receptai.api/Controllers/ImageController.cs
+++ b/receptai.api/Controllers/ImageController.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace receptai.api.Controllers;
+
+[Route("api/image")]
+[ApiController]
+public class ImageController(IImageService imageService) : ControllerBase
+{
+    private readonly IImageService _imageService = imageService;
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetById([FromRoute] int id)
+    {
+        var bytes = await _imageService.FetchImageAsync(id);
+        if (bytes == null)
+        {
+            return NotFound();
+        }
+
+        return File(bytes, "image/jpeg");
+    }
+}

--- a/receptai.api/Controllers/UserController.cs
+++ b/receptai.api/Controllers/UserController.cs
@@ -1,4 +1,5 @@
 using api.Dtos.User;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -98,6 +99,65 @@ public class UserController(UserManager<User> userManager, ITokenService tokenSe
             }
         );
     }
+
+    [HttpDelete("delete_account")]
+    [Authorize]
+    public async Task<IActionResult> DeleteUser()
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) {
+            return NotFound();
+        }
+
+        var res = await _userManager.DeleteAsync(user);
+        if (res.Succeeded) {
+            return Ok();
+        } else {
+            return BadRequest(res.Errors);
+        }
+    }
+
+    [HttpGet("info/me")]
+    [Authorize]
+    public async Task<IActionResult> GetCurrentUserInfo()
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+        {
+            return NotFound();
+        }
+
+        /* If some private data is required, this endpoint can return more than generic one */
+        return Ok(user.ToUserInfoDto());
+    }
+
+    [HttpGet("info/{id:int}")]
+    public async Task<IActionResult> GetUserInfo([FromRoute] int id)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        var user = await _userManager.FindByIdAsync(id.ToString());
+        if (user == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(user.ToUserInfoDto());
+    }
+
     [HttpPost("img")]
     [Authorize]
     public async Task<IActionResult> UploadUserImg(IFormFile file)

--- a/receptai.api/Dtos/User/UserInfoDto.cs
+++ b/receptai.api/Dtos/User/UserInfoDto.cs
@@ -1,0 +1,10 @@
+﻿namespace receptai.api;
+
+public class UserInfoDto
+{
+    public int Id { get; set;}
+    public string Username { get; set; }
+    public DateTime JoinDate { get; set; }
+    public int? ImageId { get; set; }
+    public int KarmaScore { get; set; }
+}

--- a/receptai.api/Interfaces/IImageRepository.cs
+++ b/receptai.api/Interfaces/IImageRepository.cs
@@ -1,0 +1,8 @@
+﻿namespace receptai.api;
+
+public interface IImageRepository
+{
+    Task<int> UploadImageAsync(byte[] bytes);
+    Task<byte[]?> RetrieveImageAsync(int imageId);
+    Task<bool> DeleteImageAsync(int imageId);
+}

--- a/receptai.api/Interfaces/IImageService.cs
+++ b/receptai.api/Interfaces/IImageService.cs
@@ -1,0 +1,20 @@
+﻿namespace receptai.api;
+
+public record struct ImageDimensions
+{
+    public ImageDimensions() {}
+
+    /* If both are zero then image is not resized */
+    /* If one is zero, then image is resized to dimension, but keeping aspect ratio */
+    /* If both are non-zero, then image is resized to those dimensions (or less, if KeepAspectRatio specified) */
+    public int Width = 0;
+    public int Height = 0;
+    public bool KeepAspectRatio = false;
+}
+
+public interface IImageService
+{
+    Task<int> StoreImageAsync(Stream file, ImageDimensions? dimensions);
+    Task<byte[]?> FetchImageAsync(int imageId);
+    Task<bool> DeleteImageAsync(int imageId);
+}

--- a/receptai.api/Mappers/UserMappers.cs
+++ b/receptai.api/Mappers/UserMappers.cs
@@ -1,0 +1,20 @@
+﻿using receptai.data;
+
+namespace receptai.api;
+
+public static class UserMappers
+{
+    public static UserInfoDto ToUserInfoDto(
+        this User userModel)
+    {
+        return new UserInfoDto
+        {
+            Id = userModel.Id,
+            Username = userModel.UserName!,
+            JoinDate = userModel.JoinDate,
+            ImageId = userModel.ImgId,
+            /* This prob needs to be dynamically accessed */
+            KarmaScore = userModel.KarmaScore,
+        };
+    }
+}

--- a/receptai.api/Program.cs
+++ b/receptai.api/Program.cs
@@ -79,7 +79,9 @@ builder.Services.AddScoped<IRecipeRepository, RecipeRepository>();
 builder.Services.AddScoped<ISubfoodditRepository, SubfoodditRepository>();
 builder.Services.AddScoped<ICommentRepository, CommentRepository>();
 builder.Services.AddScoped<ISubfoodditRepository, SubfoodditRepository>();
+builder.Services.AddScoped<IImageRepository, ImageRepository>();
 builder.Services.AddScoped<ITokenService, TokenService>();
+builder.Services.AddScoped<IImageService, ImageService>();
 
 var app = builder.Build();
 

--- a/receptai.api/Repositories/ImageRepository.cs
+++ b/receptai.api/Repositories/ImageRepository.cs
@@ -1,0 +1,42 @@
+﻿
+using receptai.data;
+
+namespace receptai.api;
+
+public class ImageRepository(RecipePlatformDbContext context) : IImageRepository
+{
+    private readonly RecipePlatformDbContext _context = context;
+
+    public async Task<bool> DeleteImageAsync(int imageId)
+    {
+        var img = await _context.Images.FindAsync(imageId);
+        if (img == null)
+        {
+            return false;
+        }
+        else
+        {
+            _context.Images.Remove(img);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+    }
+
+    public async Task<byte[]?> RetrieveImageAsync(int imageId)
+    {
+        var img = await _context.Images.FindAsync(imageId);
+        return img?.ImageData;
+    }
+
+    public async Task<int> UploadImageAsync(byte[] bytes)
+    {
+        Image img = new()
+        {
+            ImgId = 0,
+            ImageData = bytes,
+        };
+        var ent = await _context.Images.AddAsync(img);
+        await _context.SaveChangesAsync();
+        return ent.Entity.ImgId;
+    }
+}

--- a/receptai.api/Services/ImageService.cs
+++ b/receptai.api/Services/ImageService.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.IO;
+using System.Threading.Tasks;
+using System.Linq;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Formats.Jpeg;
+
+namespace receptai.api;
+
+public class ImageService(IImageRepository imageRepo) : IImageService
+{
+    private readonly IImageRepository _imageRepo = imageRepo;
+
+    public async Task<bool> DeleteImageAsync(int imageId)
+    {
+        return await _imageRepo.DeleteImageAsync(imageId);
+    }
+
+    public async Task<byte[]?> FetchImageAsync(int imageId)
+    {
+        return await _imageRepo.RetrieveImageAsync(imageId);
+    }
+
+    public async Task<int> StoreImageAsync(Stream file, ImageDimensions? dimensions)
+    {
+        using var image = Image.Load(file);
+        if (dimensions.HasValue)
+        {
+            var resizeOptions = new ResizeOptions
+            {
+                Mode = dimensions.Value.KeepAspectRatio ? ResizeMode.Max : ResizeMode.Stretch,
+                Size = new Size(dimensions.Value.Width, dimensions.Value.Height)
+            };
+            image.Mutate(x => x.Resize(resizeOptions));
+        }
+        
+        var jpegEncoder = new JpegEncoder
+        {
+            Quality = 75
+        };
+
+        /* Hella inefficient, but w/e (essentially 3-4 copies of image data) */
+        using var outputStream = new MemoryStream();
+        await image.SaveAsync(outputStream, jpegEncoder);
+        return await _imageRepo.UploadImageAsync(outputStream.ToArray());
+    }
+}

--- a/receptai.api/receptai.api.csproj
+++ b/receptai.api/receptai.api.csproj
@@ -26,6 +26,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Changes:
- Added image service, repository & controller
- Added profile picture upload & deletion to user controller
- Added user info retrieval & user profile deletion to user controller

User info can be retrieved either via info/{id}, when searching for arbitrary profile info, or info/me, which will return info about currently authenticated user (The /me endpoint can later be changed to return information which is private to the user)