### PR TITLE
[PSK-88] feat: recipe creation & update - photo upload

### DIFF
--- a/receptai.api/Controllers/UserController.cs
+++ b/receptai.api/Controllers/UserController.cs
@@ -193,10 +193,15 @@ public class UserController(UserManager<User> userManager, ITokenService tokenSe
             /* Check if user already has image */
             if (user.ImgId != null)
             {
-                await _imageService.DeleteImageAsync(user.ImgId.Value);
+                int oldId = user.ImgId.Value;
+                user.ImgId = id;
+                await _imageService.DeleteImageAsync(oldId);
+            }
+            else
+            {
+                user.ImgId = id;
             }
 
-            user.ImgId = id;
             await _userManager.UpdateAsync(user);
 
             return Ok(id);

--- a/receptai.api/Dtos/Recipe/CreateRecipeRequestDto.cs
+++ b/receptai.api/Dtos/Recipe/CreateRecipeRequestDto.cs
@@ -8,22 +8,21 @@ public class CreateRecipeRequestDto
     [MaxLength(255, ErrorMessage = "Title may not be longer than 255 characters!")]
     public string Title { get; set; } = null!;
 
-    public int? ImgId { get; set; }
-
     [Required]
     public int SubfoodditId { get; set; }
+
+    public IFormFile? Photo { get; set; }
 
     [Required]
     public string Ingredients { get; set; } = null!;
 
     public string? CookingTime { get; set; } = null!;
 
+    [Required]
     [Range(1, int.MaxValue, ErrorMessage = "Servings must be a positive number!")]
     public int Servings { get; set; }
 
     [Required]
-    public DateTime DatePosted { get; set; }
-
     [Range(1, 10, ErrorMessage = "Difficulty must be rated between 1 and 10!")]
     public int CookingDifficulty { get; set; }
 

--- a/receptai.api/Dtos/Recipe/UpdateRecipeRequestDto.cs
+++ b/receptai.api/Dtos/Recipe/UpdateRecipeRequestDto.cs
@@ -8,18 +8,15 @@ public class UpdateRecipeRequestDto
     [MaxLength(255, ErrorMessage = "Title may not be longer than 255 characters!")]
     public string Title { get; set; } = null!;
 
-    public int? ImgId { get; set; }
-
     [Required]
     public string Ingredients { get; set; } = null!;
+
+    public IFormFile? Photo { get; set; }
 
     public string? CookingTime { get; set; } = null!;
 
     [Range(1, int.MaxValue, ErrorMessage = "Servings must be a positive number!")]
     public int Servings { get; set; }
-
-    [Required]
-    public DateTime DatePosted { get; set; }
 
     [Range(1, 10, ErrorMessage = "Difficulty must be rated between 1 and 10!")]
     public int CookingDifficulty { get; set; }

--- a/receptai.api/Interfaces/IRecipeRepository.cs
+++ b/receptai.api/Interfaces/IRecipeRepository.cs
@@ -12,7 +12,7 @@ public interface IRecipeRepository
     Task<Recipe> CreateAsync(Recipe recipeModel);
 
     Task<Recipe?> UpdateAsync(int id,
-        UpdateRecipeRequestDto recipeDto);
+        UpdateRecipeRequestDto recipeDto, int? imageId, bool remove_photo);
     
     Task<Recipe?> DeleteAsync(int id);
 

--- a/receptai.api/Mappers/RecipeMappers.cs
+++ b/receptai.api/Mappers/RecipeMappers.cs
@@ -32,12 +32,11 @@ public static class RecipeMappers
         return new Recipe
         {
             Title = recipeModel.Title,
-            ImgId = recipeModel.ImgId,
             SubfoodditId = recipeModel.SubfoodditId,
             Ingredients = recipeModel.Ingredients,
             CookingTime = recipeModel.CookingTime,
             Servings = recipeModel.Servings,
-            DatePosted = recipeModel.DatePosted,
+            DatePosted = DateTime.UtcNow,
             CookingDifficulty = recipeModel.CookingDifficulty,
             Instructions = recipeModel.Instructions
         };

--- a/receptai.api/Repositories/RecipeRepository.cs
+++ b/receptai.api/Repositories/RecipeRepository.cs
@@ -62,23 +62,33 @@ public class RecipeRepository : IRecipeRepository
             .ToListAsync();
     }
 
-    public async Task<Recipe?> UpdateAsync(int id,
-        UpdateRecipeRequestDto recipeDto)
+    public async Task<Recipe?> UpdateAsync(int id, UpdateRecipeRequestDto recipeDto, int? imageId, bool remove_image)
     {
         var existingRecipe = await _context.Recipes
             .FirstOrDefaultAsync(x => x.RecipeId == id);
-
         if (existingRecipe is null)
         {
             return null;
         }
 
+        if (imageId != null || remove_image) {
+            if (existingRecipe.ImgId != null) {
+                var existing_img = await _context.Images.FindAsync(existingRecipe.ImgId.Value);
+                existingRecipe.ImgId = imageId;
+                if (existing_img != null) {
+                    _context.Images.Remove(existing_img);
+                }
+            }
+            else
+            {
+                existingRecipe.ImgId = imageId;
+            }
+        }
+        
         existingRecipe.Title = recipeDto.Title;
-        existingRecipe.ImgId = recipeDto.ImgId;
         existingRecipe.Ingredients = recipeDto.Ingredients;
         existingRecipe.CookingTime = recipeDto.CookingTime;
         existingRecipe.Servings = recipeDto.Servings;
-        existingRecipe.DatePosted = recipeDto.DatePosted;
         existingRecipe.CookingDifficulty = recipeDto.CookingDifficulty;
         existingRecipe.Instructions = recipeDto.Instructions;
 


### PR DESCRIPTION
Changes:
- Remove DatePosted from Create & Update recipe requests & instead set from server side
- Add uploading of file for Create & Update recipe requests
  - Required conversion from body to form post request
- Optional query path for update to instead remove photo (meaning if just no image is posted, then it's assumed to keep old, however if query path is provided then image is removed)

Had to do something pretty scuffed in UpdateAsync of recipe repo, because if I remove image and only then update recipe, for some reason, it removes the whole recipe from DB 🫠