### PR TITLE
[PSK-73] Pagination of Recipes + [PSK-98] Subfooddit minor fix

### DIFF
--- a/receptai.api/Controllers/RecipeController.cs
+++ b/receptai.api/Controllers/RecipeController.cs
@@ -28,9 +28,9 @@ public class RecipeController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<IActionResult> GetAll()
+    public async Task<IActionResult> GetAll([FromQuery] int offset = 0, [FromQuery] int limit = 10)
     {
-        var recipes = await _recipeRepository.GetAllAsync();
+        var recipes = await _recipeRepository.GetAllAsync(offset, limit);
         var recipeDto = recipes.Select(r => r.ToRecipeDto());
 
         return Ok(recipeDto);
@@ -50,19 +50,21 @@ public class RecipeController : ControllerBase
     }
 
     [HttpGet("by_user/{userId}")]
-    public async Task<IActionResult> GetRecipesByUserId(int userId)
+    public async Task<IActionResult> GetRecipesByUserId(int userId, [FromQuery] int offset = 0, [FromQuery] int limit = 10)
     {
-        var recipes = await _recipeRepository.GetRecipesByUserId(userId);
+        var recipes = await _recipeRepository.GetRecipesByUserId(userId, offset, limit);
+        var recipeDto = recipes.Select(r => r.ToRecipeDto());
 
-        return Ok(recipes);
+        return Ok(recipeDto);
     }
 
     [HttpGet("by_subfooddit/{subfoodditId}")]
-    public async Task<IActionResult> GetRecipesBySubfoodditId(int subfoodditId)
+    public async Task<IActionResult> GetRecipesBySubfoodditId(int subfoodditId, [FromQuery] int offset = 0, [FromQuery] int limit = 10)
     {
-        var recipes = await _recipeRepository.GetRecipesBySubfoodditId(subfoodditId);
+        var recipes = await _recipeRepository.GetRecipesBySubfoodditId(subfoodditId, offset, limit);
+        var recipeDto = recipes.Select(r => r.ToRecipeDto());
 
-        return Ok(recipes);
+        return Ok(recipeDto);
     }
 
     [HttpGet("aggregated_votes/{id:int}")]

--- a/receptai.api/Dtos/Subfooddit/CreateSubfoodditRequestDto.cs
+++ b/receptai.api/Dtos/Subfooddit/CreateSubfoodditRequestDto.cs
@@ -10,8 +10,4 @@ public class CreateSubfoodditRequestDto
 
     [MaxLength(5000, ErrorMessage = "Description may not be longer than 5000 characters!")]
     public string? Description { get; set; }
-
-    [Required]
-    public DateTime CreationDate { get; set; }
-
 }

--- a/receptai.api/Dtos/Subfooddit/UpdateSubfoodditRequestDto.cs
+++ b/receptai.api/Dtos/Subfooddit/UpdateSubfoodditRequestDto.cs
@@ -13,7 +13,4 @@ public class UpdateSubfoodditRequestDto
     [MaxLength(5000, ErrorMessage = "Description may not be longer than 5000 characters!")]
     public string? Description { get; set; }
 
-    [Required]
-    public DateTime CreationDate { get; set; }
-
 }

--- a/receptai.api/Interfaces/IRecipeRepository.cs
+++ b/receptai.api/Interfaces/IRecipeRepository.cs
@@ -5,7 +5,7 @@ namespace receptai.api.Interfaces;
 
 public interface IRecipeRepository
 {
-    Task<List<Recipe>> GetAllAsync();
+    Task<List<Recipe>> GetAllAsync(int offset = 0, int limit = 50);
 
     Task<Recipe?> GetByIdAsync(int id);
 
@@ -18,7 +18,7 @@ public interface IRecipeRepository
 
     Task<int> RecalculateVotesAsync(int recipeId);
 
-    Task<List<Recipe>> GetRecipesByUserId(int userId);
+    Task<List<Recipe>> GetRecipesByUserId(int userId, int offset = 0, int limit = 50);
 
-    Task<List<Recipe>> GetRecipesBySubfoodditId(int subfoodditId);
+    Task<List<Recipe>> GetRecipesBySubfoodditId(int subfoodditId, int offset = 0, int limit = 50);
 }

--- a/receptai.api/Mappers/SubfoodditMappers.cs
+++ b/receptai.api/Mappers/SubfoodditMappers.cs
@@ -23,7 +23,7 @@ public static class SubfoodditMappers
         {
             Title = subfoodditModel.Title,
             Description = subfoodditModel.Description,
-            CreationDate = subfoodditModel.CreationDate,
+            CreationDate = DateTime.UtcNow,
         };
     }
 }

--- a/receptai.api/Repositories/RecipeRepository.cs
+++ b/receptai.api/Repositories/RecipeRepository.cs
@@ -38,9 +38,15 @@ public class RecipeRepository : IRecipeRepository
         return recipeModel;
     }
 
-    public async Task<List<Recipe>> GetAllAsync()
+    public async Task<List<Recipe>> GetAllAsync(int offset = 0, int limit = 10)
     {
-        return await _context.Recipes.ToListAsync();
+        if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset), "Offset should be greater than or equal to 0.");
+        if (limit < 1) throw new ArgumentOutOfRangeException(nameof(limit), "Limit should be greater than or equal to 1.");
+
+        return await _context.Recipes
+            .Skip(offset)
+            .Take(limit)
+            .ToListAsync();
     }
 
     public async Task<Recipe?> GetByIdAsync(int id)
@@ -48,17 +54,27 @@ public class RecipeRepository : IRecipeRepository
         return await _context.Recipes.FindAsync(id);
     }
 
-    public async Task<List<Recipe>> GetRecipesByUserId(int userId)
+    public async Task<List<Recipe>> GetRecipesByUserId(int userId, int offset = 0, int limit = 10)
     {
+        if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset), "Offset should be greater than or equal to 0.");
+        if (limit < 1) throw new ArgumentOutOfRangeException(nameof(limit), "Limit should be greater than or equal to 1.");
+
         return await _context.Recipes
             .Where(r => r.UserId == userId)
+            .Skip(offset)
+            .Take(limit)
             .ToListAsync();
     }
 
-    public async Task<List<Recipe>> GetRecipesBySubfoodditId(int subfoodditId)
+    public async Task<List<Recipe>> GetRecipesBySubfoodditId(int subfoodditId, int offset = 0, int limit = 10)
     {
+        if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset), "Offset should be greater than or equal to 0.");
+        if (limit < 1) throw new ArgumentOutOfRangeException(nameof(limit), "Limit should be greater than or equal to 1.");
+
         return await _context.Recipes
             .Where(r => r.SubfoodditId == subfoodditId)
+            .Skip(offset)
+            .Take(limit)
             .ToListAsync();
     }
 

--- a/receptai.api/Repositories/SubfoodditRepository.cs
+++ b/receptai.api/Repositories/SubfoodditRepository.cs
@@ -63,7 +63,6 @@ public class SubfoodditRepository : ISubfoodditRepository
 
         existingSubfooddit.Title = subfoodditDto.Title;
         existingSubfooddit.Description = subfoodditDto.Description;
-        existingSubfooddit.CreationDate = subfoodditDto.CreationDate;
 
         await _context.SaveChangesAsync();
 


### PR DESCRIPTION
[RECIPE]
Implemented pagination for the _GetAll_, _GetRecipesByUserId_, and _GetRecipesBySubfoodditId_ methods. Users can now specify the page number (_PageNumber_, default is 1) and the number of items per page (_PageSize_, default is 10).

[SUBFOODDIT]
When editing Subfooddit information, users can no longer modify the _CreationDate_ field.